### PR TITLE
Add davecli to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN go get -u github.com/micromata/dave/cmd/...
 FROM alpine:latest  
 RUN apk update && apk upgrade
 RUN adduser -S dave
+COPY --from=0 /go/bin/davecli /usr/local/bin
 COPY --from=0 /go/bin/dave /usr/local/bin
 USER dave
 ENTRYPOINT ["/usr/local/bin/dave"]


### PR DESCRIPTION
This allows a user to use davecli to generate password hashes when using the docker image.
```
docker container exec -it containerid davecli
docker-compose exec dave davecli
```