### PR TITLE
Add CORS preflight and credentials handling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,10 +102,11 @@ doesn't need a passphrase. Otherwise starting the server will fail.
 
 In case you intend to operate this server from a web browser based application,
 you might need to allow [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
-access. To achieve that, you can configure the hosts you want to grant access to:
+access. To achieve that, you can configure the host you want to grant access to:
 
 	cors:
-		origin: "*"
+		origin: "*"        # the origin to allow, or '*' for all
+        credentials: true  # whether to allow credentials via CORS
 
 Note however that this has security implications, so be careful in production
 environments.

--- a/app/config.go
+++ b/app/config.go
@@ -46,7 +46,8 @@ type UserInfo struct {
 
 // Cors contains settings related to Cross-Origin Resource Sharing (CORS)
 type Cors struct {
-	Origin string
+	Origin      string
+	Credentials bool
 }
 
 // ParseConfig parses the application configuration an sets defaults.
@@ -101,6 +102,7 @@ func setDefaults() {
 	viper.SetDefault("Log.Read", false)
 	viper.SetDefault("Log.Update", false)
 	viper.SetDefault("Log.Delete", false)
+	viper.SetDefault("Cors.Credentials", false)
 }
 
 func (cfg *Config) AuthenticationNeeded() bool {

--- a/app/security.go
+++ b/app/security.go
@@ -72,6 +72,16 @@ func AuthFromContext(ctx context.Context) *AuthInfo {
 }
 
 func handle(ctx context.Context, w http.ResponseWriter, req *http.Request, a *App) {
+	// handle a preflight if such a CORS request would be allowed
+	if req.Method == "OPTIONS" {
+		if a.Config.Cors.Origin == req.Header.Get("Origin") &&
+			req.Header.Get("Access-Control-Request-Method") != "" &&
+			req.Header.Get("Access-Control-Request-Headers") != "" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+
 	// if there are no users, we don't need authentication here
 	if !a.Config.AuthenticationNeeded() {
 		a.Handler.ServeHTTP(w, req.WithContext(ctx))

--- a/cmd/dave/main.go
+++ b/cmd/dave/main.go
@@ -80,6 +80,9 @@ func wrapRecovery(handler http.Handler, config *app.Config) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", config.Cors.Origin)
 			w.Header().Set("Access-Control-Allow-Headers", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "*")
+			if config.Cors.Credentials {
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+			}
 		}
 
 		handler.ServeHTTP(w, r)


### PR DESCRIPTION
Without CORS preflight handling, cross-origin browser requests will be rejected. Likewise, without setting ALLOW-CREDENTIALS, credentialed cross-origin requests will be rejected. This PR adds both features.