### PR TITLE
use single quotes in sample config

### DIFF
--- a/examples/config-sample.yaml
+++ b/examples/config-sample.yaml
@@ -2,15 +2,15 @@
 #
 # The bind address to use
 #
-address: "0.0.0.0"
+address: '0.0.0.0'
 #
 # The listening port
 #
-port: "8000"
+port: '8000'
 #
 # The prefix path of the server. Default none
 #
-#prefix: "/"
+#prefix: '/'
 
 # ---------------------------- Transport security ------------------------------
 #tls:
@@ -23,14 +23,14 @@ port: "8000"
 #
 # The provided base dir
 #
-dir: "/tmp"
+dir: '/tmp'
 
 
 # --------------------------------- Basic Auth ---------------------------------
 #
 # Name of the basic auth realm
 #
-realm: "dave"
+realm: 'dave'
 
 # ----------------------------------- Users ------------------------------------
 #
@@ -41,14 +41,14 @@ users:
   # user with username 'user', password 'foo' and jailed access to '/tmp/user'
   #
   user:
-    password: "$2a$10$yITzSSNJZAdDZs8iVBQzkuZCzZ49PyjTiPIrmBUKUpB0pwX7eySvW"
-    subdir: "/user"
+    password: '$2a$10$yITzSSNJZAdDZs8iVBQzkuZCzZ49PyjTiPIrmBUKUpB0pwX7eySvW'
+    subdir: '/user'
 
   #
   # user with username 'admin', password 'foo' and access to '/tmp'
   #
   admin:
-    password: "$2a$10$yITzSSNJZAdDZs8iVBQzkuZCzZ49PyjTiPIrmBUKUpB0pwX7eySvW"
+    password: '$2a$10$yITzSSNJZAdDZs8iVBQzkuZCzZ49PyjTiPIrmBUKUpB0pwX7eySvW'
 
 
 # ---------------------------------- Logging -----------------------------------
@@ -68,4 +68,4 @@ users:
 # Use the following section to enable Cross-origin access to the server.
 #
 #cors:
-#  origin: "*"
+#  origin: '*'


### PR DESCRIPTION
unix-y users are unaffected, but this makes life easier for Windows users:

Windows-users are likely to edit
dir: "/tmp"
to something like
dir: "C:\Users\username\whatever"

and as explained in https://github.com/micromata/dave/issues/31#issuecomment-880377263 
>\U, \\\U, \u and \\\u makes golang expect a eight or four character unicode, which is why it expects a hexadecimal number.

and dave will then spew the rather cryptic message
>dave.exe
time="2023-03-22T23:13:20+01:00" level=fatal msg="Fatal error config file: While parsing config: yaml: line 26: did not find expected hexdecimal number"

but with this change, Windows-users are more likely to change it into something like dir: 'C:\Users\username\whatever'

and Dave will start just fine :)