### PR TITLE
Update Dockerfile to Build With Go 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine AS build
+FROM golang:1.17.13-alpine AS build
 WORKDIR $GOPATH/src/github.com/micromata/dave/
 COPY . .
 RUN go build -o /go/bin/dave cmd/dave/main.go


### PR DESCRIPTION
Tried building the Dockerfile but it failed due to Go 1.17 being required. Potentially want an even later version of Go but figured I would offer my ever so slightly changed Dockerfile to make the path a little smoother for those in the future. 

Thanks for the repo, it was exactly what I was looking for.