### PR TITLE
Dockerfile: Update base Golang version. Add 'dave' group.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM golang:1.16.3-alpine AS build
+FROM golang:1.21.3-alpine AS build
 WORKDIR $GOPATH/src/github.com/micromata/dave/
 COPY . .
 RUN go build -o /go/bin/dave cmd/dave/main.go
 RUN go build -o /go/bin/davecli cmd/davecli/main.go
 
 FROM alpine:latest  
-RUN adduser -S dave
+RUN addgroup -g 1000 dave
+RUN adduser -S -G dave -u 1000 dave
 COPY --from=build /go/bin/davecli /usr/local/bin
 COPY --from=build /go/bin/dave /usr/local/bin
 USER dave


### PR DESCRIPTION
Fixes #59. Supercedes #58.

* Updated Golang base image to latest (as of Oct'23: 1.21.3). I might pin it to just `1.21` to use whatever latest 1.21.x is, if desired.
* As done in #58, ensures the group `dave` with GID 1000 exists and explicitly adds user `dave` to it, resulting in `1000:1000` UID:GID. As done with the user, group is also added as system (`-S`).

Notice: keep an eye on [micromata/dave Tags on Docker Hub](https://hub.docker.com/r/micromata/dave/tags) to check if the Github Action builds successfully. The Docker image is quite outdated (eg. the `--config` switch doesn't work as per readme).